### PR TITLE
TypeError: "NoneType" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **Kobo Composite Markup Generator** is a Python script designed to help Kobo Libre Color 2 users export and manage their markups more efficiently. Since Kobo does not provide a straightforward solution for exporting markups, this script offers a custom approach by processing your markup files and generating composite images that overlay annotations on your original book pages.
+The **Kobo Composite Markup Generator** is a Python script designed to help Kobo Libra Colour users export and manage their markups more efficiently. Since Kobo does not provide a straightforward solution for exporting markups, this script offers a custom approach by processing your markup files and generating composite images that overlay annotations on your original book pages.
 
 ## Features
 
@@ -14,9 +14,10 @@ The **Kobo Composite Markup Generator** is a Python script designed to help Kobo
 
 ## Prerequisites
 
-- **Kobo Libre Color 2**: This script was ran on a Kobo Libre Color 2 Device.
+- **Kobo Libra Colour**: This script was ran on a Kobo Libra Colour Device.
 - **Anaconda or Miniconda**: Required for managing the Python environment.
 - **Python 3.13.1**: The script was developed and tested with Python version 3.13.1.
+- **GTK-for-Windows-Runtime-Environment-Installer**: This was  needed to get CairoSVG to work on a clean Windows 11 machine. (Miniconda was installed) [Get it Here](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer)
 
 ## Setup Instructions
 

--- a/kobo_composite_markup_generator.py
+++ b/kobo_composite_markup_generator.py
@@ -81,16 +81,29 @@ def get_book_part_number_for_bookmark(bookmark_id):
     cursor.execute(query, (bookmark_id,))
     row = cursor.fetchone()
     
+    """
+    This part of the code generated TypeError: "NoneType" object is not subscriptable Probably because I had inside the
+    "markups" folder a set of jpg + svg that match a book that was no longer in the "KoboReader.sqlite" the revised code was
+    added starting at line 101.
+    
     unclean_part_name = str(row[0]).split("/")
     part_name_with_html = unclean_part_name[-1].split(".")
-
+    """
     cursor.close()
     conn.close()
     
+    # Original Code:
+    """
     if row:
         return part_name_with_html[0]
     return None
-
+    """
+    if row: # Check if row is not None
+        unclean_part_name = str(row[0]).split("/")
+        part_name_with_html = unclean_part_name[-1].split(".")
+        return part_name_with_html[0]
+    return None
+    
 import sqlite3
 import re
 


### PR DESCRIPTION
Getting TypeError: "NoneType" when trying to match JPG + SVG pair on a book that is not in the KoboReader.sqlite Database.

Also Added GTX dependency reference in the "Prerequisites" Section since it was needed to get CairoSVG to work in Windows 11 (Clean Install)

And I have no clue what device Kobo Libre Color 2 is So I assume you meant the "Kobo Libra Colour" But I can be wrong.

Thank you for the script.
![Missing Something](https://github.com/user-attachments/assets/e6fe4080-9ef6-4203-8420-c44cfa0ec142)
![unclear check if none](https://github.com/user-attachments/assets/50294078-9be8-4c8d-bfbf-e57380bef6c7)
